### PR TITLE
Update Dockerfile for new base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ RUN apt-get install git -y
 
 USER anaconda
 WORKDIR /main/workflow-array-ephys
+
+# Install DataJoint's remote fork of elements and workflow
 RUN git clone https://github.com/datajoint/workflow-array-ephys.git .
+
 RUN pip install .
 RUN pip install -r requirements_test.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM datajoint/djlab:py3.7-debian
+FROM datajoint/djlab:py3.8-debian
 
-RUN mkdir /main/workflow-array-ephys
+USER root
+RUN apt-get update -y
+RUN apt-get install git -y
 
+USER anaconda
 WORKDIR /main/workflow-array-ephys
-
-RUN git clone https://github.com/ttngu207/workflow-array-ephys.git .
-
+RUN git clone https://github.com/datajoint/workflow-array-ephys.git .
 RUN pip install .
 RUN pip install -r requirements_test.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,21 @@ RUN apt-get install git -y
 USER anaconda
 WORKDIR /main/workflow-array-ephys
 
-# Install DataJoint's remote fork of elements and workflow
+# Option 1 - Install DataJoint's remote fork of the workflow and elements
 RUN git clone https://github.com/datajoint/workflow-array-ephys.git .
 
-RUN pip install .
-RUN pip install -r requirements_test.txt
+# Option 2 - Install user's remote fork of element and workflow 
+#            or an unreleased version of the element
+# RUN pip install git+https://github.com/<user>/element-array-ephys.git
+# RUN git clone https://github.com/<user>/workflow-array-ephys.git /main/workflow-array-ephys
+
+# Option 3 - Install user's local fork of element and workflow
+# RUN mkdir /main/element-array-ephys
+# COPY --chown=anaconda:anaconda ./element-array-ephys /main/element-array-ephys
+# RUN pip install /main/element-array-ephys
+# COPY --chown=anaconda:anaconda ./workflow-array-ephys /main/workflow-array-ephys
+# RUN rm /main/workflow-array-ephys/dj_local_conf.json
+
+# Install the workflow
+RUN pip install /main/workflow-array-ephys
+RUN pip install -r /main/workflow-array-ephys/requirements_test.txt

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -13,7 +13,7 @@ services:
     build:
       context: ../
       dockerfile: ./workflow-array-ephys/Dockerfile
-    image: workflow_array_ephys:0.1.0a2
+    image: workflow_array_ephys:0.1.0a3
     environment:
       - DJ_HOST=db
       - DJ_USER=root

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -3,12 +3,12 @@ x-net: &net
   networks:
       - main
 services:
-  db:
+  database:
     <<: *net
     image: datajoint/mysql:5.7
     environment:
       - MYSQL_ROOT_PASSWORD=simple
-  workflow_array_ephys:
+  workflow:
     <<: *net
     build:
       context: .
@@ -30,7 +30,7 @@ services:
       - ${TEST_DATA_DIR}:/main/test_data
       - ./apt_requirements.txt:/tmp/apt_requirements.txt
     depends_on:
-      db:
+      database:
         condition: service_healthy
 networks:
   main:

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -12,7 +12,7 @@ services:
     <<: *net
     build:
       context: .
-    image: workflow_array_ephys:v0.0.0
+    image: workflow_array_ephys:0.1.0a2
     environment:
       - DJ_HOST=db
       - DJ_USER=root

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -3,7 +3,7 @@ x-net: &net
   networks:
       - main
 services:
-  database:
+  db:
     <<: *net
     image: datajoint/mysql:5.7
     environment:
@@ -31,7 +31,7 @@ services:
       - ${TEST_DATA_DIR}:/main/test_data
       - ./apt_requirements.txt:/tmp/apt_requirements.txt
     depends_on:
-      database:
+      db:
         condition: service_healthy
 networks:
   main:

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -11,7 +11,8 @@ services:
   workflow:
     <<: *net
     build:
-      context: .
+      context: ../
+      dockerfile: ./workflow-array-ephys/Dockerfile
     image: workflow_array_ephys:0.1.0a2
     environment:
       - DJ_HOST=db

--- a/workflow_array_ephys/version.py
+++ b/workflow_array_ephys/version.py
@@ -2,4 +2,4 @@
 Package metadata
 Update the Docker image tag in `docker-compose-test.yaml` to match
 """
-__version__ = '0.1.0a2'
+__version__ = '0.1.0a3'

--- a/workflow_array_ephys/version.py
+++ b/workflow_array_ephys/version.py
@@ -1,2 +1,5 @@
-"""Package metadata."""
+"""
+Package metadata
+Update the Docker image tag in `docker-compose-test.yaml` to match
+"""
 __version__ = '0.1.0a2'


### PR DESCRIPTION
- Update Dockerfile to work with new `djlab` base image.
- Add instructions within `Dockerfile` for installing user's fork of the `element` or `workflow` for the integration tests, which will expedite the development process.  In this case the code is intentionally commented.  Additional details are in [datajoint-elements/install.md](https://github.com/kabilar/datajoint-elements/blob/main/install.md#run-integration-tests).
- All tests pass with the 3 options presented.
- Update Docker image tag in `docker-compose-test.yaml` to match the package version.