### PR TITLE
Config items to notebook 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 
 ## [0.2.1] - 2022-07-22
 + Add - Mention CodeBook data directory in notebooks
++ Add - Mention of config items in notebook 09
 + Update - Remove directory assertion in notebooks for CodeBook deployment
 + Update - Move all export functions from `pipeline` to `export` script
 

--- a/notebooks/09-NWB-export.ipynb
+++ b/notebooks/09-NWB-export.ipynb
@@ -46,6 +46,30 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f2161a4e",
+   "metadata": {},
+   "source": [
+    "CodeBook users should also set a couple additional config parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f9c423ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "username_as_prefix = dj.config[\"database.user\"] + \"_\"\n",
+    "if not dj.config['custom']:\n",
+    "    dj.config['custom'] = {}\n",
+    "dj.config['custom'].update({\n",
+    "        \"ephys_mode\": \"no-curation\",\n",
+    "        \"database.prefix\": username_as_prefix,\n",
+    "        })"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "84b2c6ae-b8cd-47b8-af38-812f65032933",
    "metadata": {},
    "source": [
@@ -450,7 +474,7 @@
    "formats": "ipynb,py_scripts//py"
   },
   "kernelspec": {
-   "display_name": "Python 3.10.4 64-bit ('python3p10')",
+   "display_name": "Python 3.9.12 ('ele')",
    "language": "python",
    "name": "python3"
   },
@@ -464,11 +488,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.9.12"
   },
   "vscode": {
    "interpreter": {
-    "hash": "ff52d424e56dd643d8b2ec122f40a2e279e94970100b4e6430cb9025a65ba4cf"
+    "hash": "61456c693db5d9aa6731701ec9a9b08ab88a172bee0780139a3679beb166da16"
    }
   }
  },

--- a/notebooks/py_scripts/09-NWB-export.py
+++ b/notebooks/py_scripts/09-NWB-export.py
@@ -5,9 +5,9 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.13.7
+#       jupytext_version: 1.14.0
 #   kernelspec:
-#     display_name: Python 3.10.4 64-bit ('python3p10')
+#     display_name: Python 3.9.12 ('ele')
 #     language: python
 #     name: python3
 # ---
@@ -27,6 +27,16 @@ if os.path.basename(os.getcwd())=='notebooks': os.chdir('..')
 # We'll be working with long tables, so we'll make visualization easier with a limit
 import datajoint as dj
 dj.config['display.limit']=10
+
+# CodeBook users should also set a couple additional config parameters.
+
+username_as_prefix = dj.config["database.user"] + "_"
+if not dj.config['custom']:
+    dj.config['custom'] = {}
+dj.config['custom'].update({
+        "ephys_mode": "no-curation",
+        "database.prefix": username_as_prefix,
+        })
 
 # If you haven't already populated the `lab`, `subject`, `session`, `probe`, and `ephys` schemas, please do so now with [04-automate](./04-automate-optional.ipynb). Note: exporting `ephys` data is currently only supported on the `no_curation` schema. 
 


### PR DESCRIPTION
For codebook deployment, I'd like to direct workshop attendees to notebook 9. With the specific prefix we've opened to the public, they should be able to run this notebook.