### PR TITLE
Updated `element-array-ephys` version requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
-## [0.2.6] - Unreleased
+## [0.2.6] - 2022-01-12
 
++ Update - Requirements to install main branch of `element-array-ephys`.
 + Add - Quality Metric plots to visualization notebook.
 
 ## [0.2.5] - 2022-01-03

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 datajoint>=0.13.0
-element-array-ephys @ git+https://github.com/datajoint/element-array-ephys@run_kilosort
+element-array-ephys>=0.2.2
 element-lab>=0.1.0b0
 element-animal>=0.1.0b0
 element-session>=0.1.0b0


### PR DESCRIPTION
This PR updates the requirement to using the `main` branch of `element-array-ephys` rather than the outdated `run_kilosort` branch. This will prevent errors reported [here](https://github.com/datajoint/workflow-array-ephys/issues/85). 

The issue and proposed fix were recreated and fixed in local testing. 