### PR TITLE
Update requirement for `element-array-ephys`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 
 + Update - Revise pytest and docker structure to streamline testing
 + Add - pre-commit, markdown lint, and spell check config files
++ Bugfix - `element-array-ephys` version error when installing via requirements.txt
 
 ## [0.2.6] - 2022-01-12
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 datajoint>=0.13.0
 element-animal>=0.1.0b0
-element-array-ephys>=0.2.2
+element-array-ephys @ git+https://github.com/datajoint/element-array-ephys.git
 element-electrode-localization
 element-event
 element-interface>=0.5.0


### PR DESCRIPTION
This PR updates the `requirements.txt` file to point to the main branch of `element-array-ephys` to ensure there are no errors when running `pip install -r requirements.txt`. The suggested changes in the PR fix this error and ensure the installation completes successfully